### PR TITLE
update lint rules

### DIFF
--- a/build_tools/markdownlint/info_style.rb
+++ b/build_tools/markdownlint/info_style.rb
@@ -1,1 +1,15 @@
+# See https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md for doc
+# on creating and modifying this style file
+# rules are named by their aliases here for clarity, not their code.
+# But for instance, line-length = MD013
+
 rule 'line-length', :line_length=>100, :code_blocks=>false, :tables=> false
+
+# excluded rule for error as kramdown has a bug.
+# see https://github.com/markdownlint/markdownlint/issues/294#issuecomment-600600407
+# these are now in this info style.
+# to be put back in error style once bug fixed.
+rule 'single-h1'
+rule 'no-space-in-code'
+rule "no-duplicate-header", :allow_different_nesting => true
+rule 'first-line-h1'

--- a/build_tools/markdownlint/style.rb
+++ b/build_tools/markdownlint/style.rb
@@ -1,8 +1,21 @@
+# See https://github.com/markdownlint/markdownlint/blob/master/docs/creating_styles.md for doc
+# on creating and modifying this style file
+# rules are named by their aliases here for clarity, not their code.
+# But for instance, ul-indent = MD007
 all
 
-rule "no-duplicate-header", :allow_different_nesting => true
 rule 'no-trailing-punctuation', :punctuation=>'.,;:!'
+rule 'ul-indent', :indent=> 4
 
 exclude_rule 'no-bare-urls'
 exclude_rule 'code-block-style'
 exclude_rule 'line-length'
+
+# excluded rule for as kramdown has a bug.
+# see https://github.com/markdownlint/markdownlint/issues/294#issuecomment-600600407
+# these are now in info style.
+# to be put back in error style once bug fixed.
+exclude_rule 'single-h1'
+exclude_rule 'no-space-in-code'
+exclude_rule 'no-duplicate-header'
+exclude_rule 'first-line-h1'


### PR DESCRIPTION
exclude buggy rules and add them to info
fix list indent as 2 is not working with mkdocs

It makes it similar to the Besu Lint config.

this is part of PegaSysEng/misc#25 and PegaSysEng/misc#34